### PR TITLE
Adding txmongo

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ A curated list of awesome Python asyncio frameworks, libraries, software and res
 * [aiopg](https://github.com/aio-libs/aiopg/) - Library for accessing a PostgreSQL database.
 * [aiomysql](https://github.com/aio-libs/aiomysql) - Library for accessing a MySQL database
 * [aioodbc](https://github.com/aio-libs/aioodbc) - Library for accessing a ODBC databases.
+* [txmongo](https://github.com/twisted/txmongo) - The twisted async Python driver for MongoDB.
 * [motor](https://github.com/mongodb/motor) - The async Python driver for MongoDB.
 * [asyncio-redis](https://github.com/jonathanslenders/asyncio-redis) - Redis client for Python asyncio (PEP 3156).
 * [aiocouchdb](https://github.com/aio-libs/aiocouchdb) - CouchDB client built on top of aiohttp (asyncio).


### PR DESCRIPTION
# What is this project?

txmongo is an twisted async library used with MongoDB. It's pretty much API and feature compatible with the stock pymongo, but typically returns a deferred rather than a cursor.

# Why is it awesome?

converting from pymongo to txmongo is generally just a case of prefixing pymongo calls with "yield" and adding a "inlineCallbacks" decorator. i.e. a very easy transition and very easy for legacy sync pymongo programmers to deal with.