### PR TITLE
Add peewee-async to list of database drivers

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ A curated list of awesome Python asyncio frameworks, libraries, software and res
 * [asyncio-redis](https://github.com/jonathanslenders/asyncio-redis) - Redis client for Python asyncio (PEP 3156).
 * [aiocouchdb](https://github.com/aio-libs/aiocouchdb) - CouchDB client built on top of aiohttp (asyncio).
 * [aioes](https://github.com/aio-libs/aioes) - Asyncio compatible driver for elasticsearch.
+* [peewee-async](https://github.com/05bit/peewee-async) - ORM implementation based on [peewee](https://github.com/coleifer/peewee) and aiopg.
 
 ## Networking
 


### PR DESCRIPTION
# What is this project?

`peewee-async` is a ORM that is based on the well established [peewee](https://github.com/coleifer/peewee) project providing integration with `aiopg` for PostgreSQL and `aiomysql` for MySQL.

# Why is it awesome?

* As far as I'm aware it's the only project that currently provides an ORM. `aiopg` and `aiomysql` integrate with SQLAlchemy Core but only for the query builder and not the ORM capabilities. 
