### PR TITLE
Add asynpgsa to the list of database drivers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Find some of those *awesome* packages here and if you are missing one we count o
 *Libraries to connect to databases.*
 
 * [asyncpg](https://github.com/MagicStack/asyncpg) - Fast PostgreSQL Database Client Library for Python/asyncio.
+* [asyncpgsa] (https://github.com/CanopyTax/asyncpgsa) - Asyncpg with sqlalchemy core support.
 * [aiopg](https://github.com/aio-libs/aiopg/) - Library for accessing a PostgreSQL database.
 * [aiomysql](https://github.com/aio-libs/aiomysql) - Library for accessing a MySQL database
 * [aioodbc](https://github.com/aio-libs/aioodbc) - Library for accessing a ODBC databases.


### PR DESCRIPTION
# What is this project?
It is asyncpg but with support for SqlAlchemy

# Why is it awesome?

You get asyncpg speed/awesomeness, but can still use Sqlalchemy query builder