### PR TITLE
Fix markdown link for asyncpgsa

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Find some of those *awesome* packages here and if you are missing one we count o
 *Libraries to connect to databases.*
 
 * [asyncpg](https://github.com/MagicStack/asyncpg) - Fast PostgreSQL Database Client Library for Python/asyncio.
-* [asyncpgsa] (https://github.com/CanopyTax/asyncpgsa) - Asyncpg with sqlalchemy core support.
+* [asyncpgsa](https://github.com/CanopyTax/asyncpgsa) - Asyncpg with sqlalchemy core support.
 * [aiopg](https://github.com/aio-libs/aiopg/) - Library for accessing a PostgreSQL database.
 * [aiomysql](https://github.com/aio-libs/aiomysql) - Library for accessing a MySQL database
 * [aioodbc](https://github.com/aio-libs/aioodbc) - Library for accessing a ODBC databases.


### PR DESCRIPTION
It displayed incorrectly on most Markdown viewers, including GitHub's.

Screenshot :

<img width="804" alt="asyncpgsa" src="https://cloud.githubusercontent.com/assets/4542383/24731625/4967f5d6-1a39-11e7-9f21-e81fee29232a.png">
