### PR TITLE
asynccli

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Find some of those *awesome* packages here and if you are missing one we count o
 *Other awesome asyncio libraries.*
 
 * [aiofiles](https://github.com/Tinche/aiofiles/) - File support for asyncio.
+* [asynccli] (https://github.com/ahopkins/asynccli) - A CLI framework based on asyncio.
 
 ## Writings
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Find some of those *awesome* packages here and if you are missing one we count o
 *Other awesome asyncio libraries.*
 
 * [aiofiles](https://github.com/Tinche/aiofiles/) - File support for asyncio.
-* [asynccli] (https://github.com/ahopkins/asynccli) - A CLI framework based on asyncio.
+* [asynccli](https://github.com/ahopkins/asynccli) - A CLI framework based on asyncio.
 
 ## Writings
 


### PR DESCRIPTION
# What is this project?

A command line interface framework built off `acyncio` called [asynccli](https://github.com/ahopkins/asynccli).

# Why is it awesome?

- Most other CLI frameworks in Python do not have `asyncio` support out of the box. This is designed specifically around asynchronous CLI tool development
- It allows for real simple calls by a single function, or more extensive class based definitions that allow for nesting and arguments
