### PR TITLE
Adds aiomonitor and aiozipkin to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ Find some of those *awesome* packages here and if you are missing one we count o
 
 * [aiofiles](https://github.com/Tinche/aiofiles/) - File support for asyncio.
 * [aiodebug](https://github.com/qntln/aiodebug) - A tiny library for monitoring and testing asyncio programs.
+* [aiomonitor](https://github.com/aio-libs/aiomonitor) - adds monitor and python REPL capabilities for asyncio application.
+* [aiozipkin](https://github.com/aio-libs/aiozipkin) - Distributed tracing instrumentation for asyncio with zipkin
 
 ## Writings
 


### PR DESCRIPTION
# What is this project?
I am an author of several already listed libraries, here are two more.

[aiomonitor](https://github.com/aio-libs/aiomonitor) - adds monitor and python REPL capabilities for asyncio application.
[aiozipkin](https://github.com/aio-libs/aiozipkin) - distributed tracing instrumentation for asyncio with zipkin

# Why is it awesome?
**aiomonitor** - with this library you can connect to your running asdyncio app, list executing coroutintes, make coroutine dump, or cancel stuck ones. Also you can explore state of app with async REPL.

**aiozipkin** -  first library to support distributed tracing for asyncio apps.

