### PR TITLE
Add link to aiorun.

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Find some of those *awesome* packages here and if you are missing one we count o
 
 * [aiofiles](https://github.com/Tinche/aiofiles/) - File support for asyncio.
 * [aiodebug](https://github.com/qntln/aiodebug) - A tiny library for monitoring and testing asyncio programs.
+* [aiorun](https://github.com/cjrh/aiorun) - A `run()` function that handles all the usual boilerplate for startup and graceful shutdown.
 
 ## Writings
 


### PR DESCRIPTION
# What is this project?

`aiorun` provides a `run()` function that you use to start your asyncio-based app. 

### Links:

https://github.com/cjrh/aiorun
https://pypi.python.org/pypi/aiorun/2017.10.5

# Why is it awesome?

You pass your starting cororoutine to `aiorun.run()`.   Internally, `run()` handles all the usual boilerplate that you would normally have to do by hand. It installs signal handlers for SIGINT and SIGTERM. And when the signal is received is disables them, so your the handler won't run more than once.  During shutdown it does the `gather()`, `.cancel()`, and `run_until_complete()` steps automatically, to finish up all pending tasks. It remembers to set `return_exceptions=True` so you don't have to. It provides facilities to protect certain coroutines from cancellation, and these work better than `asyncio.shield()`.

I made this library because I wrote out the boilerplate above too many times. Now I start each new asyncio-based service with `aiorun`.  This library is particularly convenient for socket-based projects, and zeromq integration in particular. (As opposed to, e.g., frameworks like aiohttp or sanic where they provide their own versions of a "start" function)

`aiorun` is tested on Python 3.5, 3.6 and nightlies, and has 100% line coverage and 100% branch coverage.

As far as I know, there are no other projects like this, i.e., that provide a `run()` function.