### PR TITLE
Add websockets in web frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Find some of those *awesome* packages here and if you are missing one we count o
 * [Kyoukai](https://github.com/SunDwarf/Kyoukai) - Fully async web framework for Python3.5+ using asyncio.
 * [cirrina](https://github.com/neolynx/cirrina) - Opinionated asynchronous web framework based on aiohttp.
 * [autobahn](https://github.com/crossbario/autobahn-python) - WebSocket and WAMP supporting asyncio and Twisted, for clients and servers.
+* [websockets](https://github.com/aaugustin/websockets/) - A library for building WebSocket servers and clients in Python with a focus on correctness and simplicity.
 
 ## Message Queues
 


### PR DESCRIPTION
This web framework is built on top of asyncio, Python’s standard asynchronous I/O framework, it provides an elegant coroutine-based API.