### PR TITLE
Add aiozipkin

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Find some of those *awesome* packages here and if you are missing one we count o
 * [aiofiles](https://github.com/Tinche/aiofiles/) - File support for asyncio.
 * [aiodebug](https://github.com/qntln/aiodebug) - A tiny library for monitoring and testing asyncio programs.
 * [aiorun](https://github.com/cjrh/aiorun) - A `run()` function that handles all the usual boilerplate for startup and graceful shutdown.
+* [aiozipkin](https://github.com/aio-libs/aiozipkin) - Distributed tracing instrumentation for asyncio with zipkin
 
 ## Writings
 


### PR DESCRIPTION
# What is this project?
[aiozipkin](https://github.com/aio-libs/aiozipkin) - distributed tracing instrumentation for asyncio with zipkin. It helps gather timing data needed to troubleshoot latency problems in microservice architectures. 

# Why is it awesome?
* First library to support distributed tracing for asyncio apps
* Has build in integration with aiohttp web framework

