### PR TITLE
Add Quart to the web frameworks list

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 The Python [asyncio](https://docs.python.org/3/library/asyncio.html) module introduced to the standard library with Python 3.4 provides infrastructure for writing single-threaded concurrent code using coroutines, multiplexing I/O access over sockets and other resources, running network clients and servers, and other related primitives.
 
-Asyncio is not really a brand-new technology however it appears to be very trending since a few years - especially in the Python community and with the release of Python 3.4 in March 2016. 
-Thus, it's pretty hard to keep yourself up-to-date with the most awesome packages out there. 
+Asyncio is not really a brand-new technology however it appears to be very trending since a few years - especially in the Python community and with the release of Python 3.4 in March 2016.
+Thus, it's pretty hard to keep yourself up-to-date with the most awesome packages out there.
 Find some of those *awesome* packages here and if you are missing one we count on you to [create an Issue or a Pull Request](https://github.com/timofurrer/awesome-asyncio/blob/master/CONTRIBUTING.md) with your suggestion.
 
 ## Contents
@@ -28,6 +28,7 @@ Find some of those *awesome* packages here and if you are missing one we count o
 
 * [aiohttp](https://github.com/KeepSafe/aiohttp) - Http client/server for asyncio (PEP-3156).
 * [sanic](https://github.com/channelcat/sanic) - Python 3.5+ web server that's written to go fast.
+* [Quart](https://gitlab.com/pgjones/quart) - An asyncio web microframework with the same API as Flask.
 * [Kyoukai](https://github.com/SunDwarf/Kyoukai) - Fully async web framework for Python3.5+ using asyncio.
 * [cirrina](https://github.com/neolynx/cirrina) - Opinionated asynchronous web framework based on aiohttp.
 * [autobahn](https://github.com/crossbario/autobahn-python) - WebSocket and WAMP supporting asyncio and Twisted, for clients and servers.


### PR DESCRIPTION
# What is this project?

[Quart](https://gitlab.com/pgjones/quart) is a asyncio web microframework with the same API as Flask.

# Why is it awesome?

- Quart has the same API as Flask
- Quart supports HTTP/1.1, Websockets and HTTP/2. 

Otherwise it is a very useable asyncio web framework.