### PR TITLE
Add aioredis to Database Drivers list

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Find some of those *awesome* packages here and if you are missing one we count o
 * [aiomysql](https://github.com/aio-libs/aiomysql) - Library for accessing a MySQL database
 * [aioodbc](https://github.com/aio-libs/aioodbc) - Library for accessing a ODBC databases.
 * [motor](https://github.com/mongodb/motor) - The async Python driver for MongoDB.
+* [aioredis](https://github.com/aio-libs/aioredis) - [aio-libs](https://github.com/aio-libs) Redis client (PEP 3156).
 * [asyncio-redis](https://github.com/jonathanslenders/asyncio-redis) - Redis client for Python asyncio (PEP 3156).
 * [aiocouchdb](https://github.com/aio-libs/aiocouchdb) - CouchDB client built on top of aiohttp (asyncio).
 * [aioes](https://github.com/aio-libs/aioes) - Asyncio compatible driver for elasticsearch.


### PR DESCRIPTION
## What is this project?

aioredis: https://github.com/aio-libs/aioredis

A popular Redis Client.

## Why is it awesome?

* It seems to be well maintained.
* It has many contributors.
* It's documented.
* Good open/closed issue ratio.
* It's part of [aio-libs](https://github.com/aio-libs) organization.
* MIT license.
* It works fine in my current project ;)
