### PR TITLE
Add aioinflux to 'Database Drivers'

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Find some of those *awesome* packages here and if you are missing one we count o
 * [aioredis](https://github.com/aio-libs/aioredis) - [aio-libs](https://github.com/aio-libs) Redis client (PEP 3156).
 * [asyncio-redis](https://github.com/jonathanslenders/asyncio-redis) - Redis client for Python asyncio (PEP 3156).
 * [aiocouchdb](https://github.com/aio-libs/aiocouchdb) - CouchDB client built on top of aiohttp (asyncio).
+* [aioinflux](https://github.com/plugaai/aioinflux) - InfluxDB client built on top of aiohttp.
 * [aioes](https://github.com/aio-libs/aioes) - Asyncio compatible driver for elasticsearch.
 * [peewee-async](https://github.com/05bit/peewee-async) - ORM implementation based on [peewee](https://github.com/coleifer/peewee) and aiopg.
 * [GINO](https://github.com/fantix/gino) - is a lightweight asynchronous Python ORM based on [SQLAlchemy](https://www.sqlalchemy.org/) core, with [asyncpg](https://github.com/MagicStack/asyncpg) dialect.


### PR DESCRIPTION
# What is this project?

Asynchronous Python client for [InfluxDB](https://www.influxdata.com/time-series-platform/influxdb/), a time series database. Built on top of [aiohttp](https://github.com/aio-libs/aiohttp) and [asyncio](https://docs.python.org/3/library/asyncio.html).


# Why is it awesome?
- Supports both asynchronous and blocking modes
- Provides (optional) integration with Pandas through a `dataframe` mode
- Well maintained and tested with nearly [100% coverage](https://codecov.io/gh/plugaai/aioinflux)
- Used in automated trading systems and other applications
- Can run on a [Raspberry Pi](https://github.com/plugaai/aioinflux/issues/9)!

# Disclaimer
I am the author and primary maintainer of the library 