### PR TITLE
add kubernetes_asyncio

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Find some of those *awesome* packages here and if you are missing one we count o
 * [aiodebug](https://github.com/qntln/aiodebug) - A tiny library for monitoring and testing asyncio programs.
 * [aiorun](https://github.com/cjrh/aiorun) - A `run()` function that handles all the usual boilerplate for startup and graceful shutdown.
 * [aiozipkin](https://github.com/aio-libs/aiozipkin) - Distributed tracing instrumentation for asyncio with zipkin
+* [kubernetes_asyncio](https://github.com/tomplus/kubernetes_asyncio) - Asynchronous client library for Kubernetes http://kubernetes.io/
 
 ## Writings
 


### PR DESCRIPTION
# What is this project?

kubernetes_asyncio: https://github.com/tomplus/kubernetes_asyncio

Python asynchronous client library for Kubernetes http://kubernetes.io/ 

# Why is it awesome?

* based on the official synchronous Python client (https://github.com/kubernetes-client/python)
* generated by swagger-codegen with asyncio support