### PR TITLE
Add NATS and Kafka clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Find some of those *awesome* packages here and if you are missing one we count o
 * [aioamqp](https://github.com/Polyconseil/aioamqp) - AMQP implementation using asyncio.
 * [aiozmq](https://github.com/aio-libs/aiozmq) - Asyncio (pep 3156) integration with ZeroMQ.
 * [crossbar](https://github.com/crossbario/crossbar) - Crossbar.io is a networking platform for distributed and microservice applications.
+* [asyncio-nats](https://github.com/nats-io/asyncio-nats) - Client for the NATS messaging system.
+* [aiokafka](https://github.com/aio-libs/aiokafka) - Client for Apache Kafka.
 
 ## Database Drivers
 


### PR DESCRIPTION
# What is this project?

Two very fast messaging systems: [Apache Kafka](https://kafka.apache.org/) and [NATS](https://nats.io/about/).

I am sorry for not following the guidelines closely, that is, adding two links at once. But otherwise two PRs would lead to merge conflicts, and I wouldn't want that.

# Why is it awesome?

None of these github libraries are mine, I just want to add these for completeness. NATS is advertised as the fastest MQ there is, and Kafka is quite wide-spread. Libraries have 125 and 200 stars respectively, which is pretty high.