### PR TITLE
Add aioserial

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Find some of those *awesome* packages here and if you are missing one we count o
 * [aiofiles](https://github.com/Tinche/aiofiles/) - File support for asyncio.
 * [aiodebug](https://github.com/qntln/aiodebug) - A tiny library for monitoring and testing asyncio programs.
 * [aiorun](https://github.com/cjrh/aiorun) - A `run()` function that handles all the usual boilerplate for startup and graceful shutdown.
+* [aioserial](https://github.com/changyuheng/aioserial) - A drop-in replacement of [pySerial](https://github.com/pyserial/pyserial).
 * [aiozipkin](https://github.com/aio-libs/aiozipkin) - Distributed tracing instrumentation for asyncio with zipkin
 
 ## Writings


### PR DESCRIPTION
# What is this project?

[aioserial](https://github.com/changyuheng/aioserial) combines [asyncio](https://docs.python.org/3/library/asyncio.html) and [pySerial](https://github.com/pyserial/pyserial).

# Why is it awesome?

* The only asyncio-based serial library that supports Windows.
* APIs are very similar to [pySerial](https://github.com/pyserial/pyserial), that means the learning curve is flat.
* Great performance, no busy waiting.