### PR TITLE
Add graphql-python

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Find some of those *awesome* packages here and if you are missing one we count o
 * [aiorun](https://github.com/cjrh/aiorun) - A `run()` function that handles all the usual boilerplate for startup and graceful shutdown.
 * [aioserial](https://github.com/changyuheng/aioserial) - A drop-in replacement of [pySerial](https://github.com/pyserial/pyserial).
 * [aiozipkin](https://github.com/aio-libs/aiozipkin) - Distributed tracing instrumentation for asyncio with zipkin
+* [graphql-python](https://github.com/graphql-python) - Collection of libraries providing GraphQL support for various web frameworks and databases
 
 ## Writings
 


### PR DESCRIPTION
# What is this project?

https://github.com/graphql-python - GraphQL implementation for Django, aiohttp and more, including asyncio support

TBH I don't really know what's the difference/relationship between the whole graphql-python Github org (containing various libraries) and the actual Graphene framework.

# Why is it awesome?

Looks like the core of any Python-related GraphQL efforts.

I don't know what is the appropriate place for this so I have added it to the Misc section.