### PR TITLE
Added link to the "Databases" package

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Find some of those *awesome* packages here and if you are missing one we count o
 * [peewee-async](https://github.com/05bit/peewee-async) - ORM implementation based on [peewee](https://github.com/coleifer/peewee) and aiopg.
 * [GINO](https://github.com/fantix/gino) - is a lightweight asynchronous Python ORM based on [SQLAlchemy](https://www.sqlalchemy.org/) core, with [asyncpg](https://github.com/MagicStack/asyncpg) dialect.
 * [Tortoise ORM](https://github.com/tortoise/tortoise-orm) - native multi-backend ORM with Django-like API and easy relations management.
+* [Databases](https://github.com/encode/databases) - Async database access for SQLAlchemy core, with support for PostgreSQL, MySQL, and SQLite.
 
 ## Networking
 


### PR DESCRIPTION
This pull requests adds a link to `databases`, which provides async database support for PostgreSQL, MySQL, and SQLite support, and supports using SQLAlchemy Core queries.

Unlike existing async options it is has proper cross-database support, and provides a really nice simple API onto making database queries. It transparently handles nested transactions, task-local connection management, connection pooling, and datatype coercion. It also provide proper support for rollback-isolation when running tests that interact with the database.