### PR TITLE
Add Bocadillo to web frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Find some of those *awesome* packages here and if you are missing one we count o
 * [Japronto!](https://github.com/squeaky-pl/japronto) - Experimental http toolkit built on top of uvloop and picohttpparser.
 * [Starlette](https://github.com/encode/starlette) - A lightweight ASGI framework/toolkit for building high performance services.
 * [uvicorn](https://github.com/encode/uvicorn) - The lightning-fast ASGI server.
+* [Bocadillo](https://bocadilloproject.github.io) - An async-first, productive and performant web framework that ships with carefully chosen included batteries.
 
 ## Message Queues
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Find some of those *awesome* packages here and if you are missing one we count o
 * [Starlette](https://github.com/encode/starlette) - A lightweight ASGI framework/toolkit for building high performance services.
 * [uvicorn](https://github.com/encode/uvicorn) - The lightning-fast ASGI server.
 * [FastAPI](https://github.com/tiangolo/fastapi) - A very high performance Python 3.6+ API framework based on type hints. Powered by Starlette and Pydantic.
-* [Bocadillo](https://bocadilloproject.github.io) - A productive, modern and performant Python web framework filled with asynchronous salsa.
+* [Bocadillo](https://bocadilloproject.github.io) - Fast, scalable and real-time capable web APIs for everyone.
 
 ## Message Queues
 


### PR DESCRIPTION
# What is this project?

Bocadillo is Python async web framework that brings fast, scalable and real-time capable web APIs for everyone.

- Repo: https://github.com/bocadilloproject/bocadillo
- Docs: https://bocadilloproject.github.io

<!--
**Note:** Please respect the [Contribution Guidelines](https://github.com/timofurrer/awesome-asyncio/blob/master/CONTRIBUTING.md)!
-->

# Why is it awesome?

- Bocadillo is **async-first**: no mixing of `def` and `async def` — when in doubt, use `async def`.
- Embraces ASGI3, 100%.
- First-class support for **HTTP/REST** (JSON validation is built-in!) and **real-time web** features (WebSocket, SSE).
- Intuitive routing inspired by Flask and Falcon, with extras.
- Django-style lightweight settings infrastructure.
- A focus on **reusability and modularity**: nested apps, routers, providers (async dependency injection for web views, inspired by Pytest fixtures), plugins, middleware… all reusable and sharable across projects.
- Support for GraphQL and socket.io via integrations such as [tartiflette-starlette](https://github.com/tartiflette/tartiflette-starlette) and [python-socketio](https://github.com/miguelgrinberg/python-socketio).
- Ships with a CLI for project bootstrapping.
- (Very) thorough documentation, 100% test coverage, fully type annotated.