### PR TITLE
asyncio alternatives section

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,6 @@ Find some of those *awesome* packages here and if you are missing one we count o
 *Alternative asyncio loop implementations.*
 
 * [uvloop](https://github.com/MagicStack/uvloop) - Ultra fast implementation of asyncio event loop on top of libuv.
-* [curio](https://github.com/dabeaz/curio) - The coroutine concurrency library.
-* [trio] (https://github.com/python-trio/trio) - Pythonic async I/O for humans and snake people.
 
 ## Misc
 
@@ -125,3 +123,12 @@ Find some of those *awesome* packages here and if you are missing one we count o
 * [Async/await in Python 3.5 and why it is awesome](https://www.youtube.com/watch?v=m28fiN9y_r8&t=132s) - EuroPython 2016 (Yury Selivanov).
 * [Fear and Awaiting in Async: A Savage Journey to the Heart of the Coroutine Dream](https://www.youtube.com/watch?v=E-1Y4kSsAFc) | [screencast](https://www.youtube.com/watch?v=Bm96RqNGbGo) - PyOhio 2016 keynote (David Beazley).
 * [Asynchronous Python for the Complete Beginner](https://www.youtube.com/watch?v=iG6fr81xHKA) | [slides](https://speakerdeck.com/pycon2017/miguel-grinberg-asynchronous-python-for-the-complete-beginner) - PyCon 2017 (Miguel Grinberg).
+
+## Alternatives to asyncio
+
+Alternative approaches to async programming in Python, some of which attempt to support some compatibility with `asyncio`, others are not compatible at all. 
+
+* [curio](https://github.com/dabeaz/curio) - The coroutine concurrency library.
+  * [Curio-Asyncio Bridge](https://github.com/dabeaz/curio/issues/190) - basic curio -> asyncio coroutine bridge
+* [trio](https://github.com/python-trio/trio) - Pythonic async I/O for humans and snake people.
+  * [trio-asyncio](https://github.com/python-trio/trio-asyncio) - re-implementation of the asyncio mainloop on top of Trio


### PR DESCRIPTION
# What is this project?

Original discussion: https://github.com/timofurrer/awesome-asyncio/pull/28#issuecomment-408493223

Both `trio` and `curio` are not asyncio loops, but alternative async frameworks. Only after sometime asyncio loops were implemented in them, but cavenats do apply. Which is why I proposed creating a seperate section which specifically says these are not just other `asyncio` loops, like `uvloop`.

**Note:** Please respect the [Contribution Guidelines](https://github.com/timofurrer/awesome-asyncio/blob/master/CONTRIBUTING.md)!

# Why is it awesome?

Trio and Curio are clearly still awesome, just may prove more problematic when rest of libraries are using `asyncio` and you have to switch between different async frameworks in the same programs, so users should know there is a difference.