### PR TITLE
Add async_property

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Find some of those *awesome* packages here and if you are missing one we count o
 * [aiorun](https://github.com/cjrh/aiorun) - A `run()` function that handles all the usual boilerplate for startup and graceful shutdown.
 * [aioserial](https://github.com/changyuheng/aioserial) - A drop-in replacement of [pySerial](https://github.com/pyserial/pyserial).
 * [aiozipkin](https://github.com/aio-libs/aiozipkin) - Distributed tracing instrumentation for asyncio with zipkin
+* [async_property](https://github.com/ryananguiano/async_property) - Python decorator for async properties.
 
 ## Writings
 


### PR DESCRIPTION
# What is this project?

You can use `@async_property` just as you would with `@property`, but on an async function.
```python
class Foo:
    @async_property
    async def remote_value(self):
        return await get_remote_value()
```
The property remote_value now returns an awaitable coroutine.
```python
instance = Foo()
await instance.remote_value
```


# Why is it awesome?

- Both regular and cached property.
- Cached properties can be accessed multiple times without repeating function.
- Cus duh!