### PR TITLE
Add aiter package

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Find some of those *awesome* packages here and if you are missing one we count o
 * [aiorun](https://github.com/cjrh/aiorun) - A `run()` function that handles all the usual boilerplate for startup and graceful shutdown.
 * [aioserial](https://github.com/changyuheng/aioserial) - A drop-in replacement of [pySerial](https://github.com/pyserial/pyserial).
 * [aiozipkin](https://github.com/aio-libs/aiozipkin) - Distributed tracing instrumentation for asyncio with zipkin
+* [aiter](https://github.com/richardkiss/aiter) - Useful and novel constructs building upon asynchronous iterators
 
 ## Writings
 


### PR DESCRIPTION
Added aiter library.

# What is this project?

This is a fairly new project with some general async iterator constructs, like fork and join, that have
are conceptually simple but extremely useful for allowing event streams to be transformed
in a functional programming way, and even split so that multiple handlers can each get their own
copies of the event stream, allowing code to be much less monolithic. I haven't seen these
constructs in any other asyncio library.

**Note:** Please respect the [Contribution Guidelines](https://github.com/timofurrer/awesome-asyncio/blob/master/CONTRIBUTING.md)!

# Why is it awesome?

I came up with these constructs when writing an async version of a bitcoin peer (pycoinnet, at
https://github.com/richardkiss/pycoinnet). The bitcoin protocol is a fairly messy and haphazard
set of messages, and different peer type (full node, SPV node, mempool watcher) respond to the
messages in different ways, which makes code reuse challenging.

These constructs came about after multiple rewrites, originally using asyncio.Queue objects, but
being frustrated with the difficulty of "ending" the Queue (beyond pushing None elements at the end,
which just seems gross). The introduction of asynchronous iterators were a natural fit, but I found
them challenging to use and build without encountering subtle issues like dropped or duplicate items.
So I build some general but tiny constructs that act as functors, and can be composed as much as
you like on async iterators, changing or forking their contents.

I thought these utilities might be useful beyond just pycoinnet, so I separated them out. They are not
super-well documented, but I thought it might be a good idea to get them visible to people who are
interested in this stuff to try to get some feedback. If they're not appropriate for this list for some
fixable reason, let me know and I can try to make improvements.