### PR TITLE
Added asgiref

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Find some of those *awesome* packages here and if you are missing one we count o
 * [aiorun](https://github.com/cjrh/aiorun) - A `run()` function that handles all the usual boilerplate for startup and graceful shutdown.
 * [aioserial](https://github.com/changyuheng/aioserial) - A drop-in replacement of [pySerial](https://github.com/pyserial/pyserial).
 * [aiozipkin](https://github.com/aio-libs/aiozipkin) - Distributed tracing instrumentation for asyncio with zipkin
+* [asgiref](https://github.com/django/asgiref) - Backend utils for ASGI to WSGI integration, includes sync_to_async and async_to_sync function wrappers.
 
 ## Writings
 


### PR DESCRIPTION
# What is this project?
A WSGI-ASGI integration library.

https://github.com/django/asgiref

# Why is it awesome?
- `async_to_sync` and `sync_to_async` function wrappers to help pull different parts of code together.
- stateless server base building block
- wsgi-to-asgi adapter