### PR TITLE
Add GraphQL section

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Find some of those *awesome* packages here and if you are missing one we count o
 * [Message Queues](#message-queues)
 * [Misc](#misc)
 * [Networking](#networking)
+* [GraphQL](#graphql)
 * [Testing](#testing)
 * [Web Frameworks](#web-frameworks)
 * [Talks](#talks)
@@ -75,6 +76,13 @@ Find some of those *awesome* packages here and if you are missing one we count o
 
 * [AsyncSSH](https://github.com/ronf/asyncssh) - Provides an asynchronous client and server implementation of the SSHv2 protocol.
 * [aiodns](https://github.com/saghul/aiodns) - Simple DNS resolver for asyncio
+
+## GraphQL
+
+*Libraries to build GraphQL servers.*
+
+* [Ariadne](https://ariadnegraphql.org) - Schema-first Python library for implementing GraphQL servers.
+* [Tartiflette](https://tartiflette.io/) - Schema-first Python 3.6+ GraphQL engine built on top of `libgraphqlparser`.
 
 ## Testing
 


### PR DESCRIPTION
# What is this project?

The Python async GraphQL ecosystem is expanding, and the following two projects seem to have gained enough traction to be worth included in this list.

* [Ariadne](https://github.com/mirumee/ariadne)
* [Tartiflette](https://tartiflette.io/)

Notes:

- I did not include [aiohttp-graphql](https://github.com/graphql-python/aiohttp-graphql) because the project seems unmaintained.
- I also left [graphql-core-next](https://github.com/graphql-python/graphql-core-next) out (a Python GraphQL engine mimicking the GraphQL.js API and implementation) because it is somewhat unpythonic, and not very useful in itself in my opnion.

# Why is it awesome?

Disclaimer: I only have experience with Tartiflette, which I am also a contributor to.

- Ariadne:
    - Schema-first.
    - Async is optional.
    - Built on top of graphql-core-next.
    - Built-in ASGI support.
- Tartiflette:
    - Fully compliant with the GraphQL spec.
    - Built on `libgraphqlparser`, the C library for parsing GraphQL schemas.
    - Schema-first, and extensible thanks to GraphQL directives.
    - Used in production at Dailymotion for several years I believe, in conjunction with [tartiflette-aiohttp](https://github.com/dailymotion/tartiflette-aiohttp) (@tsunammis can correct me if I'm wrong).
    - ASGI support via [tartiflette-starlette](https://github.com/tartiflette/tartiflette-starlette)