### PR TITLE
Add `tokio` event loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Find some of those *awesome* packages here and if you are missing one we count o
 
 *Alternative asyncio loop implementations.*
 
+* [tokio](https://pypi.org/project/tokio/) - Event loop on top of libev written in Rust.
 * [uvloop](https://github.com/MagicStack/uvloop) - Ultra fast implementation of asyncio event loop on top of libuv.
 
 ## Misc


### PR DESCRIPTION
## What is this project?
Async-tokio is a drop-in replacement of the built-in asyncio event loop. async-tokio is implemented in Rust and uses tokio-rs under the hood and PyO3 python binding.
### Using tokio loop
You can create an instance of the loop manually, using:
```python
import tokio

policy = tokio.EventLoopPolicy()
asyncio.set_event_loop_policy(policy)
```
### Supported api
- time api (call_at, call_later)
- sockets api (sock_xxx methods)
- tcp (client/server)
- unix domain socket
- dns
- pipes
- subprocess
- signals
- executors

UDP support is missing.
## Why is it awesome?
- There are not so many alternatives. We need more.
- Befriends Rust and Python users.

## Why is it NOT awesome?
- Development is suspended. May be adding it to the list would revive it.
