### PR TITLE
Replace abandoned aioes with aioelasticsearch

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Find some of those *awesome* packages here and if you are missing one we count o
 * [asyncio-redis](https://github.com/jonathanslenders/asyncio-redis) - Redis client for Python asyncio (PEP 3156).
 * [aiocouchdb](https://github.com/aio-libs/aiocouchdb) - CouchDB client built on top of aiohttp (asyncio).
 * [aioinflux](https://github.com/plugaai/aioinflux) - InfluxDB client built on top of aiohttp.
-* [aioes](https://github.com/aio-libs/aioes) - Asyncio compatible driver for elasticsearch.
+* [aioelasticsearch](https://github.com/aio-libs/aioelasticsearch) - Elasticsearch client.
 * [peewee-async](https://github.com/05bit/peewee-async) - ORM implementation based on [peewee](https://github.com/coleifer/peewee) and aiopg.
 * [GINO](https://github.com/fantix/gino) - is a lightweight asynchronous Python ORM based on [SQLAlchemy](https://www.sqlalchemy.org/) core, with [asyncpg](https://github.com/MagicStack/asyncpg) dialect.
 * [Tortoise ORM](https://github.com/tortoise/tortoise-orm) - native multi-backend ORM with Django-like API and easy relations management.


### PR DESCRIPTION
# What is this project?

As aioes (https://github.com/aio-libs-abandoned/aioes) is abandoned, it is highly recommended to use aioelasticsearch (https://github.com/aio-libs/aioelasticsearch) instead.
