### PR TITLE
add core-service to misc section

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ Find some of those *awesome* packages here and if you are missing one we count o
 * [aiozipkin](https://github.com/aio-libs/aiozipkin) - Distributed tracing instrumentation for asyncio with zipkin
 * [asgiref](https://github.com/django/asgiref) - Backend utils for ASGI to WSGI integration, includes sync_to_async and async_to_sync function wrappers.
 * [ruia](https://github.com/howie6879/ruia) - An async web scraping micro-framework based on asyncio.
+* [core-service](https://github.com/sarafanio/core-service) - services micro-framework (async start, async stop, nested services and task management)
+
 ## Writings
 
 *Documentation, blog posts, and other awesome writing about asyncio.*


### PR DESCRIPTION
# What is this project?

core-service helps you to organize asyncio app into set of services and tasks running in it.

Sources: https://github.com/sarafanio/core-service/
Docs: https://core-service.readthedocs.io/en/master/

# Why is it awesome?

It is inspired by ask/mode but it is much simpler and have a better testability.

Features:

* async start and stop
* nested service management and orchestration
* service task management and monitoring
* exception handling in nested services and tasks, service tree graceful shutdown
* 100% test coverage
* simple
