### PR TITLE
Added aiocells

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ Find some of those *awesome* packages here and if you are missing one we count o
 * [aiozipkin](https://github.com/aio-libs/aiozipkin) - Distributed tracing instrumentation for asyncio with zipkin
 * [asgiref](https://github.com/django/asgiref) - Backend utils for ASGI to WSGI integration, includes sync_to_async and async_to_sync function wrappers.
 * [ruia](https://github.com/howie6879/ruia) - An async web scraping micro-framework based on asyncio.
+* [aiocells](https://github.com/isbjorntrading/aiocells) - Toolkit for asynchronous and concurrent dependency graphs and data flow computation
+
 ## Writings
 
 *Documentation, blog posts, and other awesome writing about asyncio.*


### PR DESCRIPTION
# What is this project?

The project is `aiocells`. It's at https://github.com/isbjorntrading/aiocells. It's aimed at making it easier to reason about and construct asynchronous and concurrent programs.

# Why is it awesome?

* Program construction is in the form of an explicit dependency graph between computational nodes
* Concurrency and asynchrony are implied by the graph and not explicity programmed
* Implied concurrency and asynchrony allow for different computation algorithms, each embodying a different set of tradeoffs, to be applied to the same graph without modification
* Individual component nodes are easily tested in isolation
