### PR TITLE
Add aiosc

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Find some of those *awesome* packages here and if you are missing one we count o
 * [aiofiles](https://github.com/Tinche/aiofiles/) - File support for asyncio.
 * [aiodebug](https://github.com/qntln/aiodebug) - A tiny library for monitoring and testing asyncio programs.
 * [aiorun](https://github.com/cjrh/aiorun) - A `run()` function that handles all the usual boilerplate for startup and graceful shutdown.
+* [aiosc](https://github.com/artfwo/aiosc) -  Lightweight Open Sound Control implementation.
 * [aioserial](https://github.com/changyuheng/aioserial) - A drop-in replacement of [pySerial](https://github.com/pyserial/pyserial).
 * [aiozipkin](https://github.com/aio-libs/aiozipkin) - Distributed tracing instrumentation for asyncio with zipkin
 * [asgiref](https://github.com/django/asgiref) - Backend utils for ASGI to WSGI integration, includes sync_to_async and async_to_sync function wrappers.


### PR DESCRIPTION
# What is this project?

aiosc is a minimal light-weight Open Sound Control (OSC) communication module which uses asyncio for network operations and is compatible with the asyncio event loop.

https://github.com/artfwo/aiosc

**Note:** Please respect the [Contribution Guidelines](https://github.com/timofurrer/awesome-asyncio/blob/master/CONTRIBUTING.md)!

# Why is it awesome?

* The API is tight and the footprint is small.
* Simplifies OSC implementations in creative/artistic projects.