### PR TITLE
Delete the link with a deleted article

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,6 @@ Find some of those *awesome* packages here and if you are missing one we count o
 
 * [Official asyncio documentation](https://docs.python.org/3/library/asyncio.html) - Asynchronous I/O, event loop, coroutines and tasks.
 * [Short well-written intro to asyncio](http://masnun.com/2015/11/13/python-generators-coroutines-native-coroutines-and-async-await.html) - Generators, Coroutines, Native Coroutines and async/await.
-* [Async Through the looking Glass](https://hackernoon.com/async-through-the-looking-glass-d69a0a88b661) - Nice writing about it's worth using asyncio or not for specific use-cases.
 * [AsyncIO for the Working Python Developer](https://hackernoon.com/asyncio-for-the-working-python-developer-5c468e6e2e8e) - A gentle introduction to asynchronous programming from basic examples working up to URL fetching.
 * [Test limits of Python aiohttp](https://pawelmhm.github.io/asyncio/python/aiohttp/2016/04/22/asyncio-aiohttp.html) - Making 1 million requests with python-aiohttp.
 * [ASGI (Asynchronous Server Gateway Interface)](https://asgi.readthedocs.io/en/latest/) - A spiritual successor to WSGI, intended to provide a standard interface between async-capable Python web servers, frameworks, and applications.


### PR DESCRIPTION
# What is this project?

I've deleted a dead link to a 404 HackerNoon page (https://hackernoon.com/async-through-the-looking-glass-d69a0a88b661)
Haven't found any archive versions of this page, if you do, feel free to change the link instead of deleting it
