### PR TITLE
Adds dry-python/returns

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,9 @@ Find some of those *awesome* packages here and if you are missing one we count o
 * [aioserial](https://github.com/changyuheng/aioserial) - A drop-in replacement of [pySerial](https://github.com/pyserial/pyserial).
 * [aiozipkin](https://github.com/aio-libs/aiozipkin) - Distributed tracing instrumentation for asyncio with zipkin
 * [asgiref](https://github.com/django/asgiref) - Backend utils for ASGI to WSGI integration, includes sync_to_async and async_to_sync function wrappers.
+* [dry-python/returns](https://github.com/dry-python/returns) - Primitives and helpers for functional async programming.
 * [ruia](https://github.com/howie6879/ruia) - An async web scraping micro-framework based on asyncio.
+
 ## Writings
 
 *Documentation, blog posts, and other awesome writing about asyncio.*


### PR DESCRIPTION
Link: https://github.com/dry-python/returns
Docs: https://returns.readthedocs.io/en/latest/pages/future.html

# What is this project?

This project is a collection of primitives for typed functional programming.
Among others we have `Future`, `FutureResult`, and `ReaderFutureResult` monads.

You can also write your own implementation using Higher Kinded Types and our existing interfaces.

# Why is it awesome?

- The only typed functional async programming library I am aware of
- Well documented and well tested
- Supports any IO loop, not just `asyncio`, tested with `anyio`
- Provides interfaces and Higher Kinded Types to implement your own solution if you need to
