### PR TITLE
Adds aredis

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Find some of those *awesome* packages here and if you are missing one we count o
 * [aioodbc](https://github.com/aio-libs/aioodbc) - Library for accessing a ODBC databases.
 * [motor](https://github.com/mongodb/motor) - The async Python driver for MongoDB.
 * [aioredis](https://github.com/aio-libs/aioredis) - [aio-libs](https://github.com/aio-libs) Redis client (PEP 3156).
-* [aredis](https://github.com/NoneGG/aredis) - Redis client for Python asyncio (has support for redis server, sentinel and cluster)
+* [aredis](https://github.com/NoneGG/aredis) - Redis client for Python asyncio (has support for redis server, sentinel and cluster).
 * [asyncio-redis](https://github.com/jonathanslenders/asyncio-redis) - Redis client for Python asyncio (PEP 3156).
 * [aiocouchdb](https://github.com/aio-libs/aiocouchdb) - CouchDB client built on top of aiohttp (asyncio).
 * [aioinflux](https://github.com/plugaai/aioinflux) - InfluxDB client built on top of aiohttp.

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Find some of those *awesome* packages here and if you are missing one we count o
 * [aioodbc](https://github.com/aio-libs/aioodbc) - Library for accessing a ODBC databases.
 * [motor](https://github.com/mongodb/motor) - The async Python driver for MongoDB.
 * [aioredis](https://github.com/aio-libs/aioredis) - [aio-libs](https://github.com/aio-libs) Redis client (PEP 3156).
+* [aredis](https://github.com/NoneGG/aredis) - Redis client with cluster support.
 * [asyncio-redis](https://github.com/jonathanslenders/asyncio-redis) - Redis client for Python asyncio (PEP 3156).
 * [aiocouchdb](https://github.com/aio-libs/aiocouchdb) - CouchDB client built on top of aiohttp (asyncio).
 * [aioinflux](https://github.com/plugaai/aioinflux) - InfluxDB client built on top of aiohttp.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Find some of those *awesome* packages here and if you are missing one we count o
 * [aioodbc](https://github.com/aio-libs/aioodbc) - Library for accessing a ODBC databases.
 * [motor](https://github.com/mongodb/motor) - The async Python driver for MongoDB.
 * [aioredis](https://github.com/aio-libs/aioredis) - [aio-libs](https://github.com/aio-libs) Redis client (PEP 3156).
-* [aredis](https://github.com/NoneGG/aredis) - Redis client with cluster support.
+* [aredis](https://github.com/NoneGG/aredis) - Redis client for Python asyncio (has support for redis server, sentinel and cluster)
 * [asyncio-redis](https://github.com/jonathanslenders/asyncio-redis) - Redis client for Python asyncio (PEP 3156).
 * [aiocouchdb](https://github.com/aio-libs/aiocouchdb) - CouchDB client built on top of aiohttp (asyncio).
 * [aioinflux](https://github.com/plugaai/aioinflux) - InfluxDB client built on top of aiohttp.


### PR DESCRIPTION
# What is this project?

Redis client for Python asyncio (has support for redis server, sentinel and cluster)

Please add a link in this pull request: https://github.com/NoneGG/aredis

Note: Please respect the Contribution Guidelines!

# Why is it awesome?

* [aioredis](https://github.com/aio-libs/aioredis), which is already added in README, doesn't support redis cluster at the moment. But, aredis supports redis cluster.
