### PR TITLE
Add aiopath

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Find some of those *awesome* packages here and if you are missing one we count o
 
 * [aiocache](https://github.com/argaen/aiocache) - Cache manager for different backends.
 * [aiofiles](https://github.com/Tinche/aiofiles/) - File support for asyncio.
+* [aiopath](https://github.com/alexdelorenzo/aiopath) - Asynchronous `pathlib` for asyncio.
 * [aiodebug](https://github.com/qntln/aiodebug) - A tiny library for monitoring and testing asyncio programs.
 * [aiorun](https://github.com/cjrh/aiorun) - A `run()` function that handles all the usual boilerplate for startup and graceful shutdown.
 * [aioserial](https://github.com/changyuheng/aioserial) - A drop-in replacement of [pySerial](https://github.com/pyserial/pyserial).


### PR DESCRIPTION
# What is this project?

[`aiopath` is an asynchronous `pathlib` implementation for Python and `asyncio`](https://github.com/alexdelorenzo/aiopath)


# Why is it awesome?

If you're writing asynchronous Python code and want to take advantage of `pathlib'`s conveniences, but don't want to mix blocking and non-blocking I/O, then you can reach for `aiopath`.

Currently, there are no ports of `pathlib` to `asyncio` except for this one.
