### PR TITLE
Add Strawberry to list of GraphQL libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Find some of those *awesome* packages here and if you are missing one we count o
 
 * [Ariadne](https://ariadnegraphql.org) - Schema-first Python library for implementing GraphQL servers.
 * [Tartiflette](https://tartiflette.io/) - Schema-first Python 3.6+ GraphQL engine built on top of `libgraphqlparser`.
+* [Strawberry](https://strawberry.rocks) - Code-first Python 3 GraphQL server with Django, Flask and FastAPI/Starlette support.
 
 ## Testing
 


### PR DESCRIPTION
# What is this project?

Strawberry is a code-first GraphQL library with support for asyncio style resolvers which can then call your data layer to fetch or write data. Code first lets you write `dataclasses` which are turned into GraphQL schemas. Just call `print(schema)`!

# Why is it awesome?

+ The reason code-first wins out, is that you get Python types for free in your code. The generated schema can then be used in other GraphQL codegen tools for TypeScript types for example.
+ This library also has experimental Pydantic support so you can potentially use one shared class across GraphQL and other data layers and libraries.
+ The Strawberry Discord is a very friendly and helpful place.
