### PR TITLE
add aiodiskdb

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Find some of those *awesome* packages here and if you are missing one we count o
 * [aiocache](https://github.com/argaen/aiocache) - Cache manager for different backends.
 * [aiofiles](https://github.com/Tinche/aiofiles/) - File support for asyncio.
 * [aiodebug](https://github.com/qntln/aiodebug) - A tiny library for monitoring and testing asyncio programs.
+* [aiodiskdb](https://github.com/mempoolco/aiodiskdb) - Minimal, embeddable on-disk DB, tailored for asyncio.
 * [aiorun](https://github.com/cjrh/aiorun) - A `run()` function that handles all the usual boilerplate for startup and graceful shutdown.
 * [aioserial](https://github.com/changyuheng/aioserial) - A drop-in replacement of [pySerial](https://github.com/pyserial/pyserial).
 * [aiozipkin](https://github.com/aio-libs/aiozipkin) - Distributed tracing instrumentation for asyncio with zipkin


### PR DESCRIPTION
add aiodiskdb

# What is this project?

aiodiskdb is a lightweight, fast, simple append only database.

https://github.com/mempoolco/aiodiskdb

# Why is it awesome?

- Simple, fast, non blocking on disk DB, tailored for asyncio.
- Store raw bytes as data blob over multiple files.
- Customizable, to handle small and big files.
- Tested with high concurrency.