### PR TITLE
Add Prisma Client Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Find some of those *awesome* packages here and if you are missing one we count o
 * [GINO](https://github.com/fantix/gino) - is a lightweight asynchronous Python ORM based on [SQLAlchemy](https://www.sqlalchemy.org/) core, with [asyncpg](https://github.com/MagicStack/asyncpg) dialect.
 * [Tortoise ORM](https://github.com/tortoise/tortoise-orm) - native multi-backend ORM with Django-like API and easy relations management.
 * [Databases](https://github.com/encode/databases) - Async database access for SQLAlchemy core, with support for PostgreSQL, MySQL, and SQLite.
+* [Prisma Client Python](https://github.com/RobertCraigie/prisma-client-py) - An auto-generated, fully type safe ORM powered by Pydantic and tailored specifically for your schema - supports SQLite, PostgreSQL, MySQL, MongoDB, MariaDB and more.
 
 ## Networking
 


### PR DESCRIPTION
# What is this project?

https://github.com/RobertCraigie/prisma-client-py.

It is an auto-generated and fully type safe ORM powered by Pydantic - supports SQLite, PostgreSQL, MySQL, MongoDB, MariaDB and more!

# Why is it awesome?

- The *first* and *only* ORM for Python that offers full query type safety.
- Native support for usage with and without `async`
- Powered by Pydantic which makes integration with frameworks like FastAPI incredibly easy
- Language agnostic schema