### PR TITLE
Add awesomebot link checker GitHub Action

### DIFF
--- a/.github/workflows/awesomebot.yml
+++ b/.github/workflows/awesomebot.yml
@@ -1,0 +1,19 @@
+name: Check links in README.md
+
+on:
+  push:
+    branches: [ '*' ]
+  pull_request:
+    branches: [ '*' ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - uses: docker://dkhamsing/awesome_bot:latest
+      with:
+        args: /github/workspace/README.md --allow-timeout --allow 500,501,502,503,504,509,521 --allow-dupe --allow-ssl --request-delay 1 --allow-redirect
+# You can whitelist domains with --white-list https://example.com


### PR DESCRIPTION
I listened to your interview on the Talk Python To Me podcast, and you mentioned that you were looking for a way to check the links in your list for liveness. I maintain the [awesome-zsh-plugins](https://github.com/unixorn/awesome-zsh-plugins) list, and I've been using awesomebot to check all the links in it for the last couple of years.

I based this on my configuration - It ignores 5xx return codes to help prevent false positives for broken links and waits 1 second between probes so that it doesn't get rate-limited by GitHub or other sites as it checks links. This makes it pretty slow unfortunately but there's no other way for it to be reliable once there are a few dozen links at a single domain.

You can add `--white-list https://example.com/flaky-link` to cope with domains with iffy servers.

Signed-off-by: Joe Block <jpb@unixorn.net>

