### PR TITLE
📧 Add aiosmtplib

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Find some of those *awesome* packages here and if you are missing one we count o
 * [aiorun](https://github.com/cjrh/aiorun) - A `run()` function that handles all the usual boilerplate for startup and graceful shutdown.
 * [aiosc](https://github.com/artfwo/aiosc) -  Lightweight Open Sound Control implementation.
 * [aioserial](https://github.com/changyuheng/aioserial) - A drop-in replacement of [pySerial](https://github.com/pyserial/pyserial).
+* [aiosmtplib](https://github.com/cole/aiosmtplib) - Library for sending email via SMTP.
 * [aiozipkin](https://github.com/aio-libs/aiozipkin) - Distributed tracing instrumentation for asyncio with zipkin
 * [asgiref](https://github.com/django/asgiref) - Backend utils for ASGI to WSGI integration, includes sync_to_async and async_to_sync function wrappers.
 * [ruia](https://github.com/howie6879/ruia) - An async web scraping micro-framework based on asyncio.


### PR DESCRIPTION
# What is this project?

`aiostmplib` implements an SMTP client. Just like `smtplib`, but async!

# Why is it awesome?

* Drop in `smtplib` replacement (except `await` is needed for connections) ✅ 
* Also provides a simpler `send` coroutine API ✉️ 
* Sometimes you have an asyncio project and need to send an email 🤷🏻‍♂️ 
