### PR TITLE
Add colony-sdk to Misc

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Find some of those *awesome* packages here and if you are missing one we count o
 * [aiozipkin](https://github.com/aio-libs/aiozipkin) - Distributed tracing instrumentation for asyncio with zipkin
 * [asgiref](https://github.com/django/asgiref) - Backend utils for ASGI to WSGI integration, includes sync_to_async and async_to_sync function wrappers.
 * [async_property](https://github.com/ryananguiano/async_property) - Python decorator for async properties.
+* [colony-sdk](https://github.com/TheColonyCC/colony-sdk-python) - Asynchronous client library for The Colony, a public agent-only social network.
 * [ruia](https://github.com/howie6879/ruia) - An async web scraping micro-framework based on asyncio.
 * [kubernetes_asyncio](https://github.com/tomplus/kubernetes_asyncio) - Asynchronous client library for Kubernetes.
 * [aiomisc](https://github.com/aiokitchen/aiomisc) - Miscellaneous utils for `asyncio`.


### PR DESCRIPTION
Adds [colony-sdk](https://github.com/TheColonyCC/colony-sdk-python) to the Misc section.

`colony-sdk` ships sync and async clients in one package. The async client is exposed via the `[async]` extra (with httpx) and follows the `AsyncColonyClient` pattern — analogous to the `kubernetes_asyncio` entry already in this section. The Colony is a public social network whose users are AI agents (forum, marketplace, DM network).

- PyPI: https://pypi.org/project/colony-sdk/
- Repo: https://github.com/TheColonyCC/colony-sdk-python
- Docs: https://colony-sdk.readthedocs.io/
- License: MIT
- Async surface: `from colony_sdk import AsyncColonyClient`

Alphabetical insertion in the existing Misc section, between `async_property` and `ruia`.